### PR TITLE
Handle non json response from server

### DIFF
--- a/src/api/base.js
+++ b/src/api/base.js
@@ -24,8 +24,8 @@ export class BaseApi {
    * Build an URL from fragments to call the API
    * @return {string} - an URL
    */
-  getFullURL() {
-    const fragments = Array.from(arguments).map((fragment) => encodeURIComponent(fragment));
+  getFullURL(...args) {
+    const fragments = args.map((fragment) => encodeURIComponent(fragment));
     return urljoin(this.serviceUrl, ...fragments);
   }
 

--- a/src/utils/http.js
+++ b/src/utils/http.js
@@ -1,4 +1,7 @@
-import 'isomorphic-fetch';
+if (typeof process !== 'undefined') {
+  // on node, fetch already exists
+  require('isomorphic-fetch');
+}
 
 /**
  * API Response promise - resolves with the requested resource
@@ -38,12 +41,16 @@ export function handleStatus(response) {
   throw error;
 }
 
+
 export function handleBody(response) {
   if (response.status === 202 || response.status === 204) {
-    return;
+    return Promise.resolve();
   }
 
-  return response.json();
+  var contentType = response.headers.get('Content-Type') || '';
+  var isJson = contentType.indexOf('application/json') > -1;
+
+  return isJson ? response.json() : Promise.resolve();
 }
 
 export function http(method, url, data, headers = {}) {

--- a/tests/mocks/fetch.js
+++ b/tests/mocks/fetch.js
@@ -2,12 +2,17 @@ import 'isomorphic-fetch';
 
 const sandbox = sinon.sandbox.create();
 
-export function mock(status = 200, json = {}, statusText = '') {
+export function mock(status = 200, json = {}, statusText = '', headers = {'Content-Type': 'application/json'}) {
   return sandbox.stub(global, 'fetch', () => {
     return Promise.resolve({
       status: status,
       json: () => json,
-      statusText: statusText
+      statusText: statusText,
+      headers: {
+        get: (header) => {
+          return headers[header];
+        }
+      }
     });
   });
 }

--- a/tests/specs/utils/http.spec.js
+++ b/tests/specs/utils/http.spec.js
@@ -32,7 +32,7 @@ function generateTestName(method, data, headers) {
   let dataPart = data && Object.keys(data).length > 0 ? 'with data' : 'without data';
   let headersPart = headers && Object.keys(headers).length > 0 ? 'with headers' : 'without headers';
 
-  return util.format('%s %s %s', method, dataPart, headersPart);
+  return `${method} ${dataPart}, ${headersPart}`;
 }
 
 describe('HTTP', () => {


### PR DESCRIPTION
The API is not always returning JSON and it was crashing when deleting a webhook.

This makes the http util handle that case.